### PR TITLE
Fix: using __DIR__ in file paths to get correct paths. Changed how fly.toml file is generated.

### DIFF
--- a/app/Commands/LaunchCommand.php
+++ b/app/Commands/LaunchCommand.php
@@ -62,9 +62,6 @@ class LaunchCommand extends Command
         // Determine and include in-line the PHP version
         $phpVersion = (new \App\Services\GetPhpVersion)->get( $this );
 
-        // DEBUG: show __DIR__ location
-        $this->info("DIR location: " . __DIR__);
-
         // 3. Generate fly.toml file
         (new \App\Services\GenerateFlyToml( $appName, $nodeVersion, $phpVersion ))->get( $this );
 
@@ -77,7 +74,7 @@ class LaunchCommand extends Command
         else
         {
 
-            copy('resources/templates/Dockerfile', 'Dockerfile');
+            copy(__DIR__ . '/../../resources/templates/Dockerfile', 'Dockerfile');
             $this->line("Dockerfile added.");
         }
 

--- a/app/Services/GenerateFlyToml.php
+++ b/app/Services/GenerateFlyToml.php
@@ -36,7 +36,7 @@ class GenerateFlyToml
         // Generate config
         $flyToml = $this->fromTemplate();
 
-        // Writo/Override to file
+        // Write/Override to file
         file_put_contents( $this->writeToPath, $flyToml );
         $launch->line( 'Wrote config file fly.toml' );
     }
@@ -46,10 +46,20 @@ class GenerateFlyToml
      */
     public function fromTemplate(): string
     {
-        return View::make(
-            $this->templatePath,
-            [ 'appName'=>$this->appName, 'nodeVersion'=>$this->nodeVersion, 'phpVersion'=>$this->phpVersion ]
-        )->render();
+//        return View::make(
+//            $this->templatePath,
+//            [ 'appName'=>$this->appName, 'nodeVersion'=>$this->nodeVersion, 'phpVersion'=>$this->phpVersion ]
+//        )->render();
+
+        $placeholderVariables = [ 'APP_NAME'=>$this->appName, 'NODE_VERSION'=>$this->nodeVersion, 'PHP_VERSION'=>$this->phpVersion ];
+
+        $flyToml = file_get_contents(__DIR__ . "/../../resources/templates/fly.toml");
+
+        foreach ($placeholderVariables as $search => $replace) {
+            $flyToml = str_replace('$'.$search.'$', $replace, $flyToml);
+        }
+
+        return $flyToml;
     }
 
     /**

--- a/resources/templates/fly.toml
+++ b/resources/templates/fly.toml
@@ -1,0 +1,50 @@
+# fly.toml app configuration file generated
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "$APP_NAME$"
+kill_signal = "SIGINT"
+kill_timeout = 5
+primary_region = "ams"
+processes = []
+
+[build]
+[build.args]
+NODE_VERSION = "$NODE_VERSION"
+PHP_VERSION = "$PHP_VERSION$"
+
+[env]
+APP_ENV = "production"
+LOG_CHANNEL = "stderr"
+LOG_LEVEL = "info"
+LOG_STDERR_FORMATTER = "Monolog\\Formatter\\JsonFormatter"
+
+[experimental]
+auto_rollback = true
+
+[[services]]
+http_checks = []
+internal_port = 8080
+processes = ["app"]
+protocol = "tcp"
+script_checks = []
+[services.concurrency]
+hard_limit = 25
+soft_limit = 20
+type = "connections"
+
+[[services.ports]]
+force_https = true
+handlers = ["http"]
+port = 80
+
+[[services.ports]]
+handlers = ["tls", "http"]
+port = 443
+
+[[services.tcp_checks]]
+grace_period = "1s"
+interval = "15s"
+restart_limit = 0
+timeout = "2s"


### PR DESCRIPTION
Fly.toml used to be generated from fly-template.blade.php, so the attributes bag could be used to fill in the app name and php/node versions; like this: `{{ $appName }}`. I can see how it's convenient, but I've found it very confusing to use blade views for this. 
Here's how it's done now: In the `templates` folder there's a fly.toml file. In there, I've added placeholders for the variables that look like this: `$APP_NAME$` . When I get the contents of the file, I can do a `string_replace` for each of the placeholders. They're defined like this: `$placeholderVariables = [ 'APP_NAME'=>$this->appName, 'NODE_VERSION'=>$this->nodeVersion, 'PHP_VERSION'=>$this->phpVersion ];`

Here's a comparison for the app name in `fly.toml`:
Before: `app = "{{$appName}}"`
Now: `app = "$APP_NAME$"`