### PR TITLE
Create tests for Launch command 

### DIFF
--- a/app/Commands/LaunchCommand.php
+++ b/app/Commands/LaunchCommand.php
@@ -218,7 +218,7 @@ class LaunchCommand extends Command
 
     private function copyFiles()
     {
-        Process::run("cp -r " . __DIR__ . "/../../resources/templates/.fly/ .fly")
+        Process::run("cp -r " . __DIR__ . "/../../resources/templates/.fly/ ./")
                ->throw();
 
         Process::run("cp -r " . __DIR__ . "/../../resources/templates/.dockerignore .dockerignore")

--- a/app/Commands/LaunchCommand.php
+++ b/app/Commands/LaunchCommand.php
@@ -35,7 +35,7 @@ class LaunchCommand extends Command
      * @return mixed
      */
     public function handle(FlyIoService $flyIoService)
-    {
+    { 
         try
         {
             // First, check if a fly.toml is already present. If so, suggest to use the deployCommand instead.
@@ -108,6 +108,7 @@ class LaunchCommand extends Command
             ->throw()
             ->collect("data.organizations.nodes")
             ->toArray();
+            
         $userInput['organization'] = $flyIoService->askOrganizationName($organizations, $this);
 
         $regionsJson = $regionsProcess->wait()

--- a/app/Commands/LaunchCommand.php
+++ b/app/Commands/LaunchCommand.php
@@ -46,7 +46,7 @@ class LaunchCommand extends Command
                 $this->line("An existing fly.toml file was found with app name '$foundAppName'");
                 if ($this->confirm("Do you want to run the deploy command instead?"))
                 {
-                    $this->call(DeployCommand::class);
+                    return $this->call(DeployCommand::class);
                 } else return CommandAlias::SUCCESS;
             }
 

--- a/tests/Assets/orgs-graphql.json
+++ b/tests/Assets/orgs-graphql.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+      "currentUser":{"email":"test@test.com"},
+      "organizations":{
+          "nodes":[
+              {
+                  "id" : "testId",
+                  "slug" : "testSlug",
+                  "name" : "testName",
+                  "type" : "PERSONAL",
+                  "viewerRole" : "admin"
+              }
+          ]
+        }
+    }
+}

--- a/tests/Assets/regions.json
+++ b/tests/Assets/regions.json
@@ -1,0 +1,290 @@
+[
+    {
+        "Code": "ams",
+        "Name": "Amsterdam, Netherlands",
+        "Latitude": 52.374344,
+        "Longitude": 4.895439,
+        "GatewayAvailable": true,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "arn",
+        "Name": "Stockholm, Sweden",
+        "Latitude": 59.6512,
+        "Longitude": 17.9178,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "atl",
+        "Name": "Atlanta, Georgia (US)",
+        "Latitude": 33.6407,
+        "Longitude": -84.4277,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "bog",
+        "Name": "Bogotá, Colombia",
+        "Latitude": 4.70159,
+        "Longitude": -74.1469,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "bom",
+        "Name": "Mumbai, India",
+        "Latitude": 19.097403,
+        "Longitude": 72.874245,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": true
+    },
+    {
+        "Code": "bos",
+        "Name": "Boston, Massachusetts (US)",
+        "Latitude": 42.366978,
+        "Longitude": -71.02236,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "cdg",
+        "Name": "Paris, France",
+        "Latitude": 48.860874,
+        "Longitude": 2.353477,
+        "GatewayAvailable": true,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "den",
+        "Name": "Denver, Colorado (US)",
+        "Latitude": 39.7392,
+        "Longitude": -104.9847,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "dfw",
+        "Name": "Dallas, Texas (US)",
+        "Latitude": 32.778286,
+        "Longitude": -96.7984,
+        "GatewayAvailable": true,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "ewr",
+        "Name": "Secaucus, NJ (US)",
+        "Latitude": 40.789543,
+        "Longitude": -74.05653,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "eze",
+        "Name": "Ezeiza, Argentina",
+        "Latitude": -34.8222,
+        "Longitude": -58.5358,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "fra",
+        "Name": "Frankfurt, Germany",
+        "Latitude": 50.1167,
+        "Longitude": 8.6833,
+        "GatewayAvailable": true,
+        "RequiresPaidPlan": true
+    },
+    {
+        "Code": "gdl",
+        "Name": "Guadalajara, Mexico",
+        "Latitude": 20.5217,
+        "Longitude": -103.3109,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "gig",
+        "Name": "Rio de Janeiro, Brazil",
+        "Latitude": -22.8099,
+        "Longitude": -43.2505,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "gru",
+        "Name": "Sao Paulo, Brazil",
+        "Latitude": -23.549664,
+        "Longitude": -46.65435,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "hkg",
+        "Name": "Hong Kong, Hong Kong",
+        "Latitude": 22.25097,
+        "Longitude": 114.203224,
+        "GatewayAvailable": true,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "iad",
+        "Name": "Ashburn, Virginia (US)",
+        "Latitude": 39.02214,
+        "Longitude": -77.462555,
+        "GatewayAvailable": true,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "jnb",
+        "Name": "Johannesburg, South Africa",
+        "Latitude": -26.13629,
+        "Longitude": 28.20298,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "lax",
+        "Name": "Los Angeles, California (US)",
+        "Latitude": 33.9416,
+        "Longitude": -118.4085,
+        "GatewayAvailable": true,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "lhr",
+        "Name": "London, United Kingdom",
+        "Latitude": 51.516434,
+        "Longitude": -0.125656,
+        "GatewayAvailable": true,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "maa",
+        "Name": "Chennai (Madras), India",
+        "Latitude": 13.064429,
+        "Longitude": 80.25307,
+        "GatewayAvailable": true,
+        "RequiresPaidPlan": true
+    },
+    {
+        "Code": "mad",
+        "Name": "Madrid, Spain",
+        "Latitude": 40.4381,
+        "Longitude": -3.82,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "mia",
+        "Name": "Miami, Florida (US)",
+        "Latitude": 25.7877,
+        "Longitude": -80.2241,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "nrt",
+        "Name": "Tokyo, Japan",
+        "Latitude": 35.62161,
+        "Longitude": 139.74185,
+        "GatewayAvailable": true,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "ord",
+        "Name": "Chicago, Illinois (US)",
+        "Latitude": 41.891544,
+        "Longitude": -87.63039,
+        "GatewayAvailable": true,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "otp",
+        "Name": "Bucharest, Romania",
+        "Latitude": 44.4325,
+        "Longitude": 26.1039,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "phx",
+        "Name": "Phoenix, Arizona (US)",
+        "Latitude": 33.416084,
+        "Longitude": -112.00948,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "qro",
+        "Name": "Querétaro, Mexico",
+        "Latitude": 20.62,
+        "Longitude": -100.1863,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "scl",
+        "Name": "Santiago, Chile",
+        "Latitude": -33.36572,
+        "Longitude": -70.64292,
+        "GatewayAvailable": true,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "sea",
+        "Name": "Seattle, Washington (US)",
+        "Latitude": 47.6097,
+        "Longitude": -122.3331,
+        "GatewayAvailable": true,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "sin",
+        "Name": "Singapore, Singapore",
+        "Latitude": 1.3,
+        "Longitude": 103.8,
+        "GatewayAvailable": true,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "sjc",
+        "Name": "San Jose, California (US)",
+        "Latitude": 37.3516,
+        "Longitude": -121.89674,
+        "GatewayAvailable": true,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "syd",
+        "Name": "Sydney, Australia",
+        "Latitude": -33.86603,
+        "Longitude": 151.20692,
+        "GatewayAvailable": true,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "waw",
+        "Name": "Warsaw, Poland",
+        "Latitude": 52.1657,
+        "Longitude": 20.9671,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "yul",
+        "Name": "Montreal, Canada",
+        "Latitude": 45.48647,
+        "Longitude": -73.75549,
+        "GatewayAvailable": false,
+        "RequiresPaidPlan": false
+    },
+    {
+        "Code": "kat",
+        "Name": "Toronto, Canada",
+        "Latitude": 43.64463,
+        "Longitude": -79.38423,
+        "GatewayAvailable": true,
+        "RequiresPaidPlan": false
+    }
+]

--- a/tests/Feature/InspireCommandTest.php
+++ b/tests/Feature/InspireCommandTest.php
@@ -1,5 +1,0 @@
-<?php
-
-it('inspires artisans', function () {
-    $this->artisan('inspire')->assertExitCode(0);
-});

--- a/tests/Feature/LaunchCommandTest.php
+++ b/tests/Feature/LaunchCommandTest.php
@@ -2,42 +2,54 @@
 
 use Symfony\Component\Console\Command\Command as CommandAlias;
 
-it('Exits when fly.toml exists and user declines deploy prompt.', function () {
+
+/** 
+ * Fly TOML Present Features
+ */
+test('Exits when fly.toml exists and user declines deploy prompt.', function () {
 
     // PREP: Temp Copy flytoml template
     $this->createTemporaryFlyTomlFile();
 
     // ACTION: Run Launch Command + Decline deploy command
-    $this->artisan( $this::LAUNCH_STR ) 
-    ->expectsConfirmation( 'Do you want to run the deploy command instead?', 'no' )
-    ->assertExitCode( CommandAlias::SUCCESS ); 
+    $this->artisan( $this::LAUNCH_SIGNATURE )
+    ->expectsConfirmation( 
+        $this::ASK_TO_DEPLOY_INSTEAD,
+        $this::ANSWER_NO
+    )->assertExitCode( CommandAlias::SUCCESS ); 
 
     // ASSERT: Deploy Command was not called
-    $this->assertCommandNotCalled( $this::DEPLOY_STR );
+    $this->assertCommandNotCalled( $this::DEPLOY_CLASS );
     
     // CLEAN: Delete temp fly.toml 
     $this->deleteFlyTomlFileInBaseDir();
 
 });
 
-it('Triggers Deploy command when fly.toml exists and user accepts deploy prompt.', function(){
+test('Triggers Deploy command when fly.toml exists and user accepts deploy prompt.', function(){
 
     // PREP: Temp Copy flytoml template
     $this->createTemporaryFlyTomlFile();
 
     // ACTION: Run Launch Command + Accept deploy prompt
-    $this->artisan('launch')
-    ->expectsConfirmation('Do you want to run the deploy command instead?','yes');
+    $this->artisan( $this::LAUNCH_SIGNATURE )
+    ->expectsConfirmation( 
+        $this::ASK_TO_DEPLOY_INSTEAD,
+        $this::ANSWER_YES
+    );
 
     // ASSERT: Deploy commmand called
-    $this->assertCommandCalled('App\Commands\DeployCommand');
+    $this->assertCommandCalled( $this::DEPLOY_CLASS );
 
     // CLEAN: Delete temp fly.toml 
     $this->deleteFlyTomlFileInBaseDir();
     
 });
 
-it('Declines invalid app names.', function(){
+/**
+ * Input Features
+ */
+test('Declines invalid app names.', function(){
 
     // Exception Test: Not working : $this->expectException(\Illuminate\Process\Exceptions\ProcessFailedException::class);
 

--- a/tests/Feature/LaunchCommandTest.php
+++ b/tests/Feature/LaunchCommandTest.php
@@ -72,10 +72,9 @@ test( 'Exits with failure when invalid app name ', function(){
 
 });
 
-/**
- * The following test still does not work because of not being able to mock other functions that run after the feature I want to test
- * Might run this as a unit test instead
-     test( 'Selects Personal organization when only one organization is available.', function(){
+
+/**TODO:Either this or 'askOrganizationName selects Personal organization when only one organization is available.' */
+test( 'Selects Personal organization when only one organization is available.', function(){
 
         // Make sure that call to these url are mocked with predefined data
         Http::fake([
@@ -137,5 +136,5 @@ test( 'Exits with failure when invalid app name ', function(){
         ->expectsQuestion( $this::ASK_CHOOSE_APP_NAME_OR_BLANK, 'test' )
         ->expectsQuestion( 'Select additional processes to run (comma-separated)', '' );
 
-    });
-*/
+})->todo();
+

--- a/tests/Feature/LaunchCommandTest.php
+++ b/tests/Feature/LaunchCommandTest.php
@@ -7,7 +7,7 @@ it('Exits when fly.toml exists and user declines deploy prompt.', function () {
     // PREP: Temp Copy flytoml template
     $this->createTemporaryFlyTomlFile();
 
-    // ACTION: Run Launch Command + Assert EXIT ( no )
+    // ACTION: Run Launch Command + Decline deploy command
     $this->artisan( $this::LAUNCH_STR ) 
     ->expectsConfirmation( 'Do you want to run the deploy command instead?', 'no' )
     ->assertExitCode( CommandAlias::SUCCESS ); 
@@ -25,7 +25,7 @@ it('Triggers Deploy command when fly.toml exists and user accepts deploy prompt.
     // PREP: Temp Copy flytoml template
     $this->createTemporaryFlyTomlFile();
 
-    // ACTION: Run Launch Command + Assert trigger Deploy Command ( yes )
+    // ACTION: Run Launch Command + Accept deploy prompt
     $this->artisan('launch')
     ->expectsConfirmation('Do you want to run the deploy command instead?','yes');
 
@@ -39,10 +39,13 @@ it('Triggers Deploy command when fly.toml exists and user accepts deploy prompt.
 
 it('Declines invalid app names.', function(){
 
-    // Testing throwing exception not working : $this->expectException(\Illuminate\Process\Exceptions\ProcessFailedException::class);
+    // Exception Test: Not working : $this->expectException(\Illuminate\Process\Exceptions\ProcessFailedException::class);
+
+    // ACTION: Run Launch Command + Provide Invalid App Name 
+    // ASSERT: Exit Code is Failure Code
     $this->artisan('launch')
     ->expectsQuestion('Choose an app name (leave blank to generate one)','$')
-    ->assertExitCode(CommandAlias::FAILURE); // Check exit code instead of thrown exception
+    ->assertExitCode(CommandAlias::FAILURE); 
 
 });
 

--- a/tests/Feature/LaunchCommandTest.php
+++ b/tests/Feature/LaunchCommandTest.php
@@ -8,7 +8,7 @@ it('Exits when fly.toml exists and user declines deploy prompt.', function () {
     $this->createTemporaryFlyTomlFile();
 
     // ACTION: Run Launch Command + Assert EXIT ( no )
-    $this->artisan( $this::LAUNCH_STR )
+    $this->artisan( $this::LAUNCH_STR ) 
     ->expectsConfirmation( 'Do you want to run the deploy command instead?', 'no' )
     ->assertExitCode( CommandAlias::SUCCESS ); 
 
@@ -36,3 +36,14 @@ it('Triggers Deploy command when fly.toml exists and user accepts deploy prompt.
     $this->deleteFlyTomlFileInBaseDir();
     
 });
+
+it('Declines invalid app names.', function(){
+
+    // Testing throwing exception not working : $this->expectException(\Illuminate\Process\Exceptions\ProcessFailedException::class);
+    $this->artisan('launch')
+    ->expectsQuestion('Choose an app name (leave blank to generate one)','$')
+    ->assertExitCode(CommandAlias::FAILURE); // Check exit code instead of thrown exception
+
+});
+
+

--- a/tests/Feature/LaunchCommandTest.php
+++ b/tests/Feature/LaunchCommandTest.php
@@ -1,12 +1,25 @@
 <?php
 
 use Symfony\Component\Console\Command\Command as CommandAlias;
+use Illuminate\Support\Facades\Http;
+use Mockery;
 
+use Illuminate\Process\PendingProcess;
+use Illuminate\Contracts\Process\ProcessResult;
+use Illuminate\Support\Facades\Process;
+use App\Services\FlyIoService;
+use Mockery\MockInterface;
+
+
+/** 
+ * Take note that string constants like LAUNCH_SIGNATURE 
+ * are found in test/TestCase.php 
+ * */
 
 /** 
  * Fly TOML Present Features
  */
-test('Exits when fly.toml exists and user declines deploy prompt.', function () {
+test( 'Exits when fly.toml exists and user declines deploy prompt.', function () {
 
     // PREP: Temp Copy flytoml template
     $this->createTemporaryFlyTomlFile();
@@ -14,7 +27,7 @@ test('Exits when fly.toml exists and user declines deploy prompt.', function () 
     // ACTION: Run Launch Command + Decline deploy command
     $this->artisan( $this::LAUNCH_SIGNATURE )
     ->expectsConfirmation( 
-        $this::ASK_TO_DEPLOY_INSTEAD,
+        $this::ASK_TO_DEPLOY_INSTEAD, 
         $this::ANSWER_NO
     )->assertExitCode( CommandAlias::SUCCESS ); 
 
@@ -26,7 +39,7 @@ test('Exits when fly.toml exists and user declines deploy prompt.', function () 
 
 });
 
-test('Triggers Deploy command when fly.toml exists and user accepts deploy prompt.', function(){
+test( 'Triggers Deploy command when fly.toml exists and user accepts deploy prompt.', function(){
 
     // PREP: Temp Copy flytoml template
     $this->createTemporaryFlyTomlFile();
@@ -49,16 +62,80 @@ test('Triggers Deploy command when fly.toml exists and user accepts deploy promp
 /**
  * Input Features
  */
-test('Declines invalid app names.', function(){
-
-    // Exception Test: Not working : $this->expectException(\Illuminate\Process\Exceptions\ProcessFailedException::class);
+test( 'Exits with failure when invalid app name ', function(){ 
 
     // ACTION: Run Launch Command + Provide Invalid App Name 
     // ASSERT: Exit Code is Failure Code
-    $this->artisan('launch')
-    ->expectsQuestion('Choose an app name (leave blank to generate one)','$')
-    ->assertExitCode(CommandAlias::FAILURE); 
+    $this->artisan( $this::LAUNCH_SIGNATURE )
+    ->expectsQuestion( $this::ASK_CHOOSE_APP_NAME_OR_BLANK, '$' )
+    ->assertExitCode( CommandAlias::FAILURE ); 
 
 });
 
+/**
+ * The following test still does not work because of not being able to mock other functions that run after the feature I want to test
+ * Might run this as a unit test instead
+     test( 'Selects Personal organization when only one organization is available.', function(){
 
+        // Make sure that call to these url are mocked with predefined data
+        Http::fake([
+            'https://api.fly.io/graphql' => Http::response([
+                'data'=>[
+                    'currentUser'=>['email'=>'test@test.com'],
+                    'organizations'=>[
+                        'nodes'=>[
+                            [
+                                "id" => "testId",
+                                "slug" => "testSlug",
+                                "name" => "testName",
+                                "type" => "PERSONAL",
+                                "viewerRole" => "admin",
+                            ] 
+                        ]
+                    ]
+                ]
+            ])
+        ]);
+
+        // Mock Process for platform regions list
+        Process::fake([
+            'flyctl platform regions --json' => Process::describe()
+            ->output(file_get_contents('tests/Assets/resp.json'))
+            ->errorOutput('First line of error output')
+            ->exitCode(0)
+        ]);
+
+        // Mock the methods of the FlyioService
+        $pM = $this->partialMock(
+            FlyIoService::class,
+            function (MockInterface $mock) {
+
+                $mock
+                ->shouldReceive('askOrganizationName')
+                ->andReturn('stes');
+
+                $mock
+                ->shouldReceive('askPrimaryRegion')
+    
+                ->andReturn('sdfs');
+            }
+        );
+
+        $this->partialMock(
+            \App\Commands\LaunchCommand::class,
+            function(MockInterface $mock){
+                $mock->shouldReceive('setupLaravel')->once()->andReturn('testse');
+            }
+        );
+    
+        // Works
+        $user = [];
+        dd( app( \App\Commands\LaunchCommand::class)->setupLaravel( $user,  new FlyIoService()) );
+        // Does not work at all because somehow setupLaravel is not getting mocked through artisan()!
+        // Plus setupLaravel is actually private, so I cant mock it
+        $this->artisan( 'launch' )
+        ->expectsQuestion( $this::ASK_CHOOSE_APP_NAME_OR_BLANK, 'test' )
+        ->expectsQuestion( 'Select additional processes to run (comma-separated)', '' );
+
+    });
+*/

--- a/tests/Feature/LaunchCommandTest.php
+++ b/tests/Feature/LaunchCommandTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Symfony\Component\Console\Command\Command as CommandAlias;
+
+it('Exits when fly.toml exists and user declines deploy prompt.', function () {
+
+    // PREP: Temp Copy flytoml template
+    $this->createTemporaryFlyTomlFile();
+
+    // ACTION: Run Launch Command + Assert EXIT ( no )
+    $this->artisan( $this::LAUNCH_STR )
+    ->expectsConfirmation( 'Do you want to run the deploy command instead?', 'no' )
+    ->assertExitCode( CommandAlias::SUCCESS ); 
+
+    // ASSERT: Deploy Command was not called
+    $this->assertCommandNotCalled( $this::DEPLOY_STR );
+    
+    // CLEAN: Delete temp fly.toml 
+    $this->deleteFlyTomlFileInBaseDir();
+
+});
+
+it('Triggers Deploy command when fly.toml exists and user accepts deploy prompt.', function(){
+
+    // PREP: Temp Copy flytoml template
+    $this->createTemporaryFlyTomlFile();
+
+    // ACTION: Run Launch Command + Assert trigger Deploy Command ( yes )
+    $this->artisan('launch')
+    ->expectsConfirmation('Do you want to run the deploy command instead?','yes');
+
+    // ASSERT: Deploy commmand called
+    $this->assertCommandCalled('App\Commands\DeployCommand');
+
+    // CLEAN: Delete temp fly.toml 
+    $this->deleteFlyTomlFileInBaseDir();
+    
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,15 +8,25 @@ abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
 
-    /** COMMAND NAMES */
-    public const DEPLOY_STR = 'deploy'; 
-    public const LAUNCH_STR = 'launch';
+    /** COMMAND SIGNATURES */
+    public const LAUNCH_SIGNATURE = 'launch';
+
+    /** COMMAND CLASS */
+    public const DEPLOY_CLASS = 'App\Commands\DeployCommand'; 
 
     /** FILE NAMES */
     public const FLY_TOML_FILE_NAME_STR = 'fly.toml';
 
+    /** QUESTIONS */
+    public const ASK_TO_DEPLOY_INSTEAD = 'Do you want to run the deploy command instead?';
+
+    /** QUESTION ANSWERS */
+    public const ANSWER_NO = 'no';
+    public const ANSWER_YES = 'yes';
+
     /** TEMPLATE PATHS */
     public const TEMPLATE_PATH_STR = 'resources/templates';
+
 
     /** PREPARATION FUNCTIONS */
     function createTemporaryFlyTomlFile()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,4 +7,26 @@ use LaravelZero\Framework\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    /** COMMAND NAMES */
+    public const DEPLOY_STR = 'deploy'; 
+    public const LAUNCH_STR = 'launch';
+
+    /** FILE NAMES */
+    public const FLY_TOML_FILE_NAME_STR = 'fly.toml';
+
+    /** TEMPLATE PATHS */
+    public const TEMPLATE_PATH_STR = 'resources/templates';
+
+    /** PREPARATION FUNCTIONS */
+    function createTemporaryFlyTomlFile()
+    {
+        copy( $this::TEMPLATE_PATH_STR.'/'.$this::FLY_TOML_FILE_NAME_STR, $this::FLY_TOML_FILE_NAME_STR );
+    }
+
+    /** CLEAN UP FUNCTIONS  */
+    function deleteFlyTomlFileInBaseDir()
+    {
+        unlink( './'.$this::FLY_TOML_FILE_NAME_STR );
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,14 +19,14 @@ abstract class TestCase extends BaseTestCase
 
     /** QUESTIONS */
     public const ASK_TO_DEPLOY_INSTEAD = 'Do you want to run the deploy command instead?';
-
+    public const ASK_CHOOSE_APP_NAME_OR_BLANK = 'Choose an app name (leave blank to generate one)';
+    
     /** QUESTION ANSWERS */
     public const ANSWER_NO = 'no';
     public const ANSWER_YES = 'yes';
 
     /** TEMPLATE PATHS */
     public const TEMPLATE_PATH_STR = 'resources/templates';
-
 
     /** PREPARATION FUNCTIONS */
     function createTemporaryFlyTomlFile()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,42 +17,79 @@ class TestCase extends BaseTestCase
 
     /** FILE NAMES */
     public const FLY_TOML_FILE_NAME_STR = 'fly.toml';
+    public const FLY_CONFIG_FILES =  [ 'fly.toml', 'Dockerfile', '.dockerignore', '.fly/scripts/caches.sh', '.fly/entrypoint.sh'];
 
     /** QUESTIONS */
     public const ASK_TO_DEPLOY_INSTEAD = 'Do you want to run the deploy command instead?';
     public const ASK_CHOOSE_APP_NAME_OR_BLANK = 'Choose an app name (leave blank to generate one)';
+    public const ASK_SELECT_APP_PRIMARY_REGION = "Select your app's primary region";
+    public const ASK_SELECT_PROCESSES = 'Select additional processes to run (comma-separated)';
+    public const ASK_DEPLOY_APP = 'Do you want to deploy your app?';
     
     /** QUESTION ANSWERS */
     public const ANSWER_NO = 'no';
     public const ANSWER_YES = 'yes';
 
-    /** TEMPLATE PATHS */
-    public const TEMPLATE_PATH_STR = 'resources/templates';
-
     /** PREPARATION FUNCTIONS */
     function createTemporaryFlyTomlFile()
     {
-        copy( $this::TEMPLATE_PATH_STR.'/'.$this::FLY_TOML_FILE_NAME_STR, $this::FLY_TOML_FILE_NAME_STR );
+        copy( 'resources/templates/'.$this::FLY_TOML_FILE_NAME_STR, $this::FLY_TOML_FILE_NAME_STR );
     }
 
     /** CLEAN UP FUNCTIONS  */
-    function deleteFlyTomlFileInBaseDir()
+    function deleteConfigFilesDir()
     {
-        unlink( './'.$this::FLY_TOML_FILE_NAME_STR );
+        // Clean files
+        foreach( $this::FLY_CONFIG_FILES as $fileToCheck ){
+            if( file_exists($fileToCheck) )
+                $this->deleteFileInBaseDir( $fileToCheck );
+        }
+
+        // Clean directories
+        $dirs = ['./.fly/scripts', './.fly'];
+        foreach( $dirs as $dir ){
+            if( file_exists($dir) ){
+                rmdir( $dir );
+            }
+        }
+    }
+
+    function deleteFileInBaseDir( $fileName )
+    {
+        unlink( './'.$fileName );
     }
 
     /** MOCK FUNCTIONS  */
-    function organizationsMock()
+    function organizationsMock( $multiple=false )
     {
-        return [
-            [
-                "id" => "testId",
-                "slug" => "PERSONAL",
-                "name" => "testName",
-                "type" => "PERSONAL",
-                "viewerRole" => "admin",
-            ] 
-        ];
+        if( $multiple ){
+            return [
+                [
+                    "id" => "testId",
+                    "slug" => "PERSONAL",
+                    "name" => "testName",
+                    "type" => "PERSONAL",
+                    "viewerRole" => "admin",
+                ],
+                [
+                    "id" => "testId2",
+                    "slug" => "test",
+                    "name" => "test",
+                    "type" => "SHARED",
+                    "viewerRole" => "admin",
+                ] 
+            ];
+        }else{
+            return [
+                [
+                    "id" => "testId",
+                    "slug" => "PERSONAL",
+                    "name" => "testName",
+                    "type" => "PERSONAL",
+                    "viewerRole" => "admin",
+                ] 
+            ];
+        }
     }
 
     

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,7 @@ namespace Tests;
 
 use LaravelZero\Framework\Testing\TestCase as BaseTestCase;
 
-abstract class TestCase extends BaseTestCase
+class TestCase extends BaseTestCase
 {
     use CreatesApplication;
 
@@ -38,5 +38,19 @@ abstract class TestCase extends BaseTestCase
     function deleteFlyTomlFileInBaseDir()
     {
         unlink( './'.$this::FLY_TOML_FILE_NAME_STR );
+    }
+
+    /** MOCK FUNCTIONS  */
+    function organizationsMock()
+    {
+        return [
+            [
+                "id" => "testId",
+                "slug" => "testSlug",
+                "name" => "testName",
+                "type" => "PERSONAL",
+                "viewerRole" => "admin",
+            ] 
+        ];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use LaravelZero\Framework\Testing\TestCase as BaseTestCase;
 
+
 class TestCase extends BaseTestCase
 {
     use CreatesApplication;
@@ -46,11 +47,30 @@ class TestCase extends BaseTestCase
         return [
             [
                 "id" => "testId",
-                "slug" => "testSlug",
+                "slug" => "PERSONAL",
                 "name" => "testName",
                 "type" => "PERSONAL",
                 "viewerRole" => "admin",
             ] 
         ];
+    }
+
+    
+    function commandWithOutput()
+    {
+        // Command instance with output attribute 
+        
+        $out = new \Symfony\Component\Console\Output\BufferedOutput(
+            \Symfony\Component\Console\Output\OutputInterface::OUTPUT_RAW,
+            true
+        );
+
+        $comm = new \App\Commands\LaunchCommand();
+        $comm->setOutput( new \Illuminate\Console\OutputStyle( 
+            new \Symfony\Component\Console\Input\ArrayInput([]),  
+            $out 
+        ) );
+
+        return $comm;
     }
 }

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-test('example', function () {
-    expect(true)->toBeTrue();
-});

--- a/tests/Unit/FlyIoServicesTest.php
+++ b/tests/Unit/FlyIoServicesTest.php
@@ -27,15 +27,20 @@ test( 'validateAppName does not accept invalid app name.', function(){
 
 });
 
-/**TODO:Either this or 'Selects Personal organization when only one organization is available.' */
+/**Either this or 'Selects Personal organization when only one organization is available.' */
 test( 'askOrganizationName selects Personal organization when only one organization is available.', function(){
-   
-    $organizations =  $this->organizationsMock();
-    
-    $comm = new \App\Commands\LaunchCommand();
 
+    // Use functions from Test\TestCase
+    $testCase = (new \Tests\TestCase('str'));
     
+    // Args for askOrganizationName
+    $organizations = $testCase->organizationsMock();
+    $comm = $testCase->commandWithOutput();
+
+    // Run Action
     $selected = app(\App\Services\FlyIoService::class)->askOrganizationName( $organizations, $comm);
 
-    dd( $selected );
-})->todo();
+    // Assert Personal was auto selected
+    $this->assertTrue( $selected == 'PERSONAL');
+    
+});

--- a/tests/Unit/FlyIoServicesTest.php
+++ b/tests/Unit/FlyIoServicesTest.php
@@ -1,0 +1,29 @@
+<?php
+use Illuminate\Support\Facades\Http;
+use App\Services\FlyIoService;
+
+beforeEach(function(){
+    $this->flyService = new FlyIoService();
+});
+
+
+test( 'validateAppName accepts valid app name.', function(){
+   
+    $testAppName = 'an-okay-app-name'; 
+
+    $validation = $this->flyService->validateAppName( $testAppName );
+    
+    $this->assertTrue( $validation == $testAppName );
+});
+
+test( 'validateAppName does not accept invalid app name.', function(){
+
+    $testAppName = '$'; 
+
+    $this->expectException(\Illuminate\Process\Exceptions\ProcessFailedException::class);
+
+    $this->flyService->validateAppName( $testAppName );
+
+});
+
+

--- a/tests/Unit/FlyIoServicesTest.php
+++ b/tests/Unit/FlyIoServicesTest.php
@@ -1,6 +1,7 @@
 <?php
-use Illuminate\Support\Facades\Http;
+
 use App\Services\FlyIoService;
+use Mockery\MockInterface;
 
 beforeEach(function(){
     $this->flyService = new FlyIoService();
@@ -26,4 +27,15 @@ test( 'validateAppName does not accept invalid app name.', function(){
 
 });
 
+/**TODO:Either this or 'Selects Personal organization when only one organization is available.' */
+test( 'askOrganizationName selects Personal organization when only one organization is available.', function(){
+   
+    $organizations =  $this->organizationsMock();
+    
+    $comm = new \App\Commands\LaunchCommand();
 
+    
+    $selected = app(\App\Services\FlyIoService::class)->askOrganizationName( $organizations, $comm);
+
+    dd( $selected );
+})->todo();


### PR DESCRIPTION
_This PR contains:_
1. Add feature tests for the Launch command. Contains tests for: 
  a. **Handling projects with existing fly.toml file**:
         _- User declines deploy prompt - should exit, and not trigger deploy command
         - User accepts deploy prompt - should trigger deploy command_
  b. **Handling invalid app names by exiting with FAILURE**
  c. **Handling initialization of config files for simple/default user input for prompts, and exits successfully when deploy command declined**
  
2. Use DeployCommand::class result as the return value of command when user accepts prompt to deploy instead of launch when fly.toml exists 

3. Use "./" instead of ".fly" when copying files from template to base directory. This is done because when an existing ".fly" directory is available in the base directory, the copy creates a .fly directory inside the existing one 